### PR TITLE
Memorize all users and roles

### DIFF
--- a/lib/hotify.rb
+++ b/lib/hotify.rb
@@ -19,11 +19,19 @@ module Hotify
       client.get_roles.to_a.each{ |role| p role }
     end
 
+    def all_roles
+      @_all_roles ||= client.get_roles.to_a
+    end
+
     def roles_from(user: )
       role_ids = client.get_user_roles(user.id)
       role_ids.map do | role_id |
         client.get_role(role_id)
       end
+    end
+
+    def role_ids_from(user: )
+      client.get_user_roles(user.id)
     end
 
     def users
@@ -36,18 +44,19 @@ module Hotify
 
     def all_users_and_roles
       @_all_users_and_roles ||= all_users.map do | user |
-        { user: user, roles: roles_from(user: user) }
+        { user: user, role_ids: role_ids_from(user: user) }
       end
     end
 
     def role_in_user
-      all_roles = client.get_roles.to_a
       role_user = Hash.new { |h,k| h[k] = [] }
 
       all_roles.each do | role |
-        all_users_and_roles.each do | user_and_roles |
-          user_and_roles[:roles].each do | role |
-            role_user[role.name].push(user_and_roles[:user])
+        all_users_and_roles.each do | user_and_role_ids |
+          user_and_role_ids[:role_ids].each do | role_id |
+            if role.id == role_id
+              role_user[role.name].push(user_and_role_ids[:user])
+            end
           end
         end
       end

--- a/lib/hotify.rb
+++ b/lib/hotify.rb
@@ -26,20 +26,23 @@ module Hotify
       end
     end
 
-    def dump_all_users_and_roles
-      users = Hotify::Users.new
-      all_users_and_roles = users.all_users.map do | user |
+    def users
+      @_users ||= Hotify::Users.new
+    end
+
+    def all_users
+      @_all_users ||= users.all_users
+    end
+
+    def all_users_and_roles
+      @_all_users_and_roles ||= all_users.map do | user |
         { user: user, roles: roles_from(user: user) }
       end
-
-      all_users_and_roles
     end
 
     def role_in_user
-      all_users_and_roles = dump_all_users_and_roles
       all_roles = client.get_roles.to_a
       role_user = Hash.new { |h,k| h[k] = [] }
-
 
       all_roles.each do | role |
         all_users_and_roles.each do | user_and_roles |


### PR DESCRIPTION
beforfe:
- all users is get from onelogin api every time reference.
- user and role associated hash has user and role object

after
- memorize all users and roles
- user and role associated hash has user object and role ids. 