### PR TITLE
Add and Remove from role speed up and Reduce the number of API calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ end
 
 gem "onelogin"
 gem "thor"
+gem "parallel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     hotify (0.1.2)
       onelogin (~> 1.5.0)
+      parallel (~> 1.19.1)
       thor (~> 1.0.1)
 
 GEM
@@ -26,6 +27,7 @@ GEM
     onelogin (1.5.0)
       httparty (>= 0.13.7)
       nokogiri (>= 1.6.3.1)
+    parallel (1.19.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -53,6 +55,7 @@ DEPENDENCIES
   dotenv
   hotify!
   onelogin
+  parallel
   pry
   rake (~> 12.0)
   rspec (~> 3.0)

--- a/hotify.gemspec
+++ b/hotify.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv", "~> 2.7.5" 
   spec.add_dependency "onelogin", "~> 1.5.0"
   spec.add_dependency "thor", "~> 1.0.1"
+  spec.add_dependency "parallel", "~> 1.19.1"
 end

--- a/lib/hotify.rb
+++ b/lib/hotify.rb
@@ -1,5 +1,6 @@
 require "onelogin"
 require "thor"
+require "parallel"
 require "hotify/version"
 require "hotify/cli"
 require "hotify/auth"
@@ -68,12 +69,14 @@ module Hotify
       role_user
     end
 
-    def add_role(user, role)
-      client.assign_role_to_user(user.id, [role.id])
+    def add_role(user_email, role_ids)
+      user = Hotify::Users.find_by(email: user_email)
+      client.assign_role_to_user(user.id, role_ids)
     end
 
-    def leave_role(user, role)
-      client.remove_role_from_user(user.id, [role.id])
+    def leave_role(user_email, role_ids)
+      user = Hotify::Users.find_by(email: user_email)
+      client.remove_role_from_user(user.id, role_ids)
     end
 
     def find_by_name(name)

--- a/lib/hotify/cli.rb
+++ b/lib/hotify/cli.rb
@@ -44,49 +44,59 @@ module Hotify
       nil
     end
 
+    def onelogin_role_in_user
+      @_onelogin_role_in_user ||= role_in_user_dump(hotify_role.role_in_user)
+    end
+
     def add_role_by_yaml(hotify_role_users_hash)
-      hotify_role = Hotify::Role.new
-      hotify_role_users_hash.each do | role_name, user_emails |
-        role_id = role_id_by(role_name)
-        user_emails.each do | user_email |
-          user = Hotify::Users.find_by(email: user_email)
-          onelogin_user_role_ids = hotify_role.role_ids_from(user: user)
-          unless onelogin_user_role_ids.include?(role_id)
-            add!(user, role_name)
+      users_and_roles_will_add = Hash.new { |h,k| h[k] = [] }
+      hotify_role_users_hash.each do | hotify_role_name, hotify_user_emails |
+        hotify_user_emails.each do | hotify_user_email |
+          unless onelogin_role_in_user[hotify_role_name].include?(hotify_user_email)
+            users_and_roles_will_add[hotify_user_email].push(hotify_role_name)
           end
         end
       end
+
+      add!(users_and_roles_will_add)
     end
 
     def remove_role_by_yaml(hotify_role_users_hash)
-      hotify_role = Hotify::Role.new
-      onelogin_roles = hotify_role.role_in_user
-      onelogin_roles.each do | onelogin_role_name, onelogin_users |
-        onelogin_users.each do | user |
-          unless hotify_role_users_hash[onelogin_role_name].include?(user.email)
-            remove!(user, onelogin_role_name)
+      users_and_roles_will_remove = Hash.new { |h,k| h[k] = [] }
+      hotify_role_users_hash.each do | hotify_role_name, hotify_user_emails |
+        onelogin_role_in_user[hotify_role_name].each do | onelogin_user_email |
+          unless hotify_user_emails.include?(onelogin_user_email)
+            users_and_roles_will_remove[onelogin_user_email].push(hotify_role_name)
           end
+        end
+      end
+
+      remove!(users_and_roles_will_remove)
+    end
+
+    def add!(users_and_roles_will_add)
+      users_and_roles_will_add.each do |user_email, role_names|
+        if options[:dry_run]
+          puts "#{user_email} will add to:"
+          role_names.each { | role_name | puts role_name }
+        else
+          role_ids = role_names.map{ |role_name| role_id_by(role_name) }
+          hotify_role.add_role(user_email, role_ids)
+          puts "#{user_email} added to #{role_name}"
         end
       end
     end
 
-    def add!(user, role_name)
-      hotify_role = Hotify::Role.new
-      if options[:dry_run]
-        puts "#{user.email} will add to #{role_name}"
-      else
-        hotify_role.add_role(user, hotify_role.find_by_name(role_name))
-        puts "#{user.email} added to #{role_name}"
-      end
-    end
-
-    def remove!(user, role_name)
-      hotify_role = Hotify::Role.new
-      if options[:dry_run]
-        puts "#{user.email} will remove by #{role_name}"
-      else
-        hotify_role.leave_role(user, hotify_role.find_by_name(role_name))
-        puts "#{user.email} removed by #{role_name}"
+    def remove!(users_and_roles_will_remove)
+      users_and_roles_will_remove.each do |user_email, role_names|
+        if options[:dry_run]
+          puts "#{user_email} will remove by:"
+          role_names.each { | role_name | puts role_name }
+        else
+          role_ids = role_names.map{ |role_name| role_id_by(role_name) }
+          hotify_role.leave_role(user_email, role_ids)
+          puts "#{user_email} removed by #{role_name}"
+        end
       end
     end
 

--- a/lib/hotify/cli.rb
+++ b/lib/hotify/cli.rb
@@ -28,13 +28,30 @@ module Hotify
 
     private
 
+    def hotify_role
+      @_hotify_role ||= Hotify::Role.new
+    end
+
+    def role_id_names
+      @_role_id_names ||= hotify_role.all_roles.map{ | role | { id: role.id, name: role.name} }
+    end
+
+    def role_id_by(name)
+      role_id_names.each do | role_id_name |
+        return role_id_name[:id] if role_id_name[:name] == name
+      end
+
+      nil
+    end
+
     def add_role_by_yaml(hotify_role_users_hash)
       hotify_role = Hotify::Role.new
       hotify_role_users_hash.each do | role_name, user_emails |
+        role_id = role_id_by(role_name)
         user_emails.each do | user_email |
           user = Hotify::Users.find_by(email: user_email)
-          onelogin_user_role_names = hotify_role.roles_from(user: user).map{ | user_role | user_role.name }
-          unless onelogin_user_role_names.include?(role_name)
+          onelogin_user_role_ids = hotify_role.role_ids_from(user: user)
+          unless onelogin_user_role_ids.include?(role_id)
             add!(user, role_name)
           end
         end

--- a/lib/hotify/cli.rb
+++ b/lib/hotify/cli.rb
@@ -82,7 +82,8 @@ module Hotify
         else
           role_ids = role_names.map{ |role_name| role_id_by(role_name) }
           hotify_role.add_role(user_email, role_ids)
-          puts "#{user_email} added to #{role_name}"
+          puts "#{user_email} added to:"
+          role_names.each { | role_name | puts role_name }
         end
       end
     end
@@ -95,7 +96,8 @@ module Hotify
         else
           role_ids = role_names.map{ |role_name| role_id_by(role_name) }
           hotify_role.leave_role(user_email, role_ids)
-          puts "#{user_email} removed by #{role_name}"
+          puts "#{user_email} removed by:"
+          role_names.each { | role_name | puts role_name }
         end
       end
     end


### PR DESCRIPTION
Add and Remove action is very slowly.so use parallel gem, and memorize.

OneLogin API call rate limit is 5000 per hour.However, until now, it made unnecessary API calls, so I reduced the number of times.